### PR TITLE
Should be "diesel_cli" instead of "diesel-cli"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Simple wiki software.
 ## Usage
 Copy `env.example` to `.env` and modify it to suit your environment.
 
-Install `diesel-cli` and do `diesel migration run`.
+Install `diesel_cli` and do `diesel migration run`.
 
 Do `cargo run`.


### PR DESCRIPTION
Correcting typographical error in README. The actual package name is "diesel_cli".