### PR TITLE
Include flags for only building for Postgres in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Simple wiki software.
 ## Usage
 Copy `env.example` to `.env` and modify it to suit your environment.
 
-Install `diesel_cli` and do `diesel migration run`.
+Install `diesel_cli` by doing `cargo install diesel_cli --no-default-features --features "postgres"` to avoid having to install dependencies for DBMS that aren't Postgres, then do `diesel migration run`.
 
 Do `cargo run`.


### PR DESCRIPTION
The application is only intended to work with Postgres, so provide the flags for only building for it in the README.